### PR TITLE
Improve mobile responsiveness across layout and home page

### DIFF
--- a/Web_Api_Amazon/wwwroot/css/cardproduct.css
+++ b/Web_Api_Amazon/wwwroot/css/cardproduct.css
@@ -1,5 +1,5 @@
 ﻿.product-card {
-    width: 210px;
+    width: 100%;
     min-width: auto;
     height: 380px;
     background: #3B82E10D;
@@ -177,4 +177,16 @@
     gap: 12px; 
     justify-items: stretch;
     align-items: start;
+}
+
+
+@media (max-width: 768px) {
+    .product-card {
+        height: auto;
+        min-height: 360px;
+    }
+
+    .product-image {
+        height: 150px;
+    }
 }

--- a/Web_Api_Amazon/wwwroot/css/mainpage.css
+++ b/Web_Api_Amazon/wwwroot/css/mainpage.css
@@ -144,19 +144,19 @@ h2 {
 .categories {
     display: flex;
     justify-content: space-between;
-    padding: 30px 106px; /* було 40 */
+    padding: 30px 106px; /* ГЎГіГ«Г® 40 */
     font-weight: 600;
     color: #0D1B34;
-    font-size: 20px; /* зменшили */
+    font-size: 20px; /* Г§Г¬ГҐГ­ГёГЁГ«ГЁ */
 }
-/* Батьківський блок категорії */
+/* ГЃГ ГІГјГЄВіГўГ±ГјГЄГЁГ© ГЎГ«Г®ГЄ ГЄГ ГІГҐГЈГ®Г°ВіВї */
 .category-itemI {
-    position: relative; /* важливо для absolute меню */
+    position: relative; /* ГўГ Г¦Г«ГЁГўГ® Г¤Г«Гї absolute Г¬ГҐГ­Гѕ */
     display: inline-block;
     cursor: pointer;
 }
 
-/* Підкатегорії */
+/* ГЏВіГ¤ГЄГ ГІГҐГЈГ®Г°ВіВї */
 .cat-dropdownI {
     display: none;
     position: absolute;
@@ -179,7 +179,7 @@ h2 {
         transform: translateY(0);
     }
 
-    /* Стилі посилань */
+    /* Г‘ГІГЁГ«Ві ГЇГ®Г±ГЁГ«Г Г­Гј */
     .cat-dropdownI a {
         display: flex;
         align-items: center;
@@ -200,7 +200,7 @@ h2 {
 .popular, .collection {
     padding-left: 0;
     padding-right: 0;
-    margin-top: 80px; /* можна підкоригувати */
+    margin-top: 80px; /* Г¬Г®Г¦Г­Г  ГЇВіГ¤ГЄГ®Г°ГЁГЈГіГўГ ГІГЁ */
 }
 
 .products-grid {
@@ -215,7 +215,7 @@ h2 {
 }
 
 
-    /* Головні секції */
+    /* ГѓГ®Г«Г®ГўГ­Ві Г±ГҐГЄГ¶ВіВї */
     .popular h2,
     .collection h2 {
         font-family: "DM Sans", sans-serif;
@@ -388,3 +388,109 @@ h2 {
    
 
    
+
+/* ===== Mobile responsiveness fixes ===== */
+.page-wrapper,
+.hero,
+.categories,
+.popular,
+.collection,
+.recently-reviewed,
+.shop-collection,
+.promo-banner,
+.products-grid {
+    max-width: 100%;
+}
+
+.hero {
+    height: auto;
+    min-height: 260px;
+    padding: clamp(16px, 4vw, 32px);
+}
+
+.hero h1 {
+    font-size: clamp(28px, 5vw, 49px);
+    line-height: 1.2;
+    word-break: break-word;
+}
+
+.popular h2,
+.collection h2,
+.recently-reviewed h2 {
+    font-size: clamp(28px, 5vw, 48px);
+    line-height: 1.15;
+}
+
+@media (max-width: 1200px) {
+    .products-grid {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .categories {
+        padding: 20px 24px;
+        font-size: 18px;
+    }
+}
+
+@media (max-width: 768px) {
+    .categories {
+        padding: 14px 0;
+        gap: 18px;
+        justify-content: flex-start;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        font-size: 15px;
+    }
+
+    .category-itemI {
+        white-space: nowrap;
+        flex: 0 0 auto;
+    }
+
+    .products-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+    }
+
+    .promo-banner {
+        margin: 40px 0;
+        padding: 20px 16px;
+        min-height: auto;
+        flex-direction: column;
+        text-align: center;
+        gap: 16px;
+    }
+
+    .promo-banner__left,
+    .promo-banner__right {
+        justify-content: center;
+    }
+
+    .shop-collection .collection-grid {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 16px;
+        justify-items: center;
+    }
+
+    .category-card,
+    .category-card img {
+        width: min(100%, 280px);
+    }
+
+    .category-card img {
+        height: auto;
+        aspect-ratio: 1 / 1;
+    }
+}
+
+@media (max-width: 480px) {
+    .hero {
+        border-radius: 12px;
+    }
+
+    .product-card {
+        width: 100%;
+    }
+}

--- a/Web_Api_Amazon/wwwroot/css/site.css
+++ b/Web_Api_Amazon/wwwroot/css/site.css
@@ -23,6 +23,8 @@ html {
 html, body {
     margin: 0;
     padding: 0;
+    max-width: 100%;
+    overflow-x: hidden;
 }
 body {
     margin-bottom: 0;
@@ -80,6 +82,14 @@ body {
     color: var(--text-dark);
     -webkit-font-smoothing: antialiased;
     margin-bottom: 0;
+    overflow-x: hidden;
+}
+
+.container {
+    width: 100%;
+    max-width: 100%;
+    padding-left: clamp(12px, 4vw, 24px);
+    padding-right: clamp(12px, 4vw, 24px);
 }
 main {
     flex: 2; /* ����� ���� ������ �� header � footer */
@@ -1158,8 +1168,20 @@ main {
 }
 
 @media (max-width: 768px) {
+    .main-header {
+        padding: 10px 12px;
+    }
+
+    .header-inner {
+        gap: 8px;
+        min-height: auto;
+        flex-wrap: wrap;
+    }
+
     .header-left {
         gap: 8px;
+        width: 100%;
+        justify-content: space-between;
     }
 
     .header-location,
@@ -1167,14 +1189,53 @@ main {
         font-size: 13px;
     }
 
-    .header-center .cat-btn,
+    .header-center {
+        width: 100%;
+        min-width: 0;
+        order: 3;
+    }
+
+    .header-center .cat-wrapper {
+        display: none;
+    }
+
     .header-center .search-form,
     .header-center .search-btn {
         height: 40px;
     }
 
     .header-right {
+        width: 100%;
+        justify-content: flex-end;
         gap: 2px;
+    }
+
+    .profile-dropdown,
+    .cat-dropdown {
+        max-width: calc(100vw - 24px);
+    }
+
+    .site-footer {
+        padding-top: 28px;
+    }
+
+    .footer-inner {
+        padding: 0 16px;
+    }
+
+    .footer-links {
+        flex-direction: column;
+        gap: 20px;
+    }
+
+    .site-footer__title {
+        margin-bottom: 10px;
+    }
+
+    .site-footer__bottom {
+        align-items: flex-start;
+        justify-content: flex-start;
+        gap: 12px;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Make the whole site adaptive to mobile devices so header, footer and pages render correctly on small screens.
- Prevent horizontal page overflow/left-right scrolling on mobile viewport.
- Ensure homepage hero, category strip and product cards scale and stay readable on phone-sized screens.

### Description
- Updated global layout styles in `Web_Api_Amazon/wwwroot/css/site.css` to prevent horizontal overflow by adding `max-width: 100%`, `overflow-x: hidden` and a fluid `.container` with responsive side padding, and added mobile header/footer layout rules (wrapping header rows, capping dropdown widths, stacking footer columns).
- Added responsive rules to `Web_Api_Amazon/wwwroot/css/mainpage.css` to scale the hero, headings and section layouts, make the categories strip scrollable on small screens, and adjust promo/collection layouts and product grid breakpoints.
- Made product cards fluid by changing sizing in `Web_Api_Amazon/wwwroot/css/cardproduct.css` (`.product-card` set to `width: 100%`) and added mobile-specific image/height adjustments so cards fit in 2-column mobile grids.
- Hid desktop-only category selector in the header on small viewports and constrained dropdowns to `calc(100vw - 24px)` to avoid overflow.

### Testing
- Attempted `dotnet build Amazon-clone.sln` to validate the app build, but the `dotnet` SDK is not available in this environment so the build could not run (failed).
- Attempted an automated mobile screenshot using Playwright against `http://127.0.0.1:5000` to visually validate mobile layout, but the web app was not running (navigation failed with `ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7fda71fe4832caef8164100347e45)